### PR TITLE
docs: Fix simple typo, resuts -> result

### DIFF
--- a/jwHash.h
+++ b/jwHash.h
@@ -31,7 +31,7 @@ limitations under the License.
 #endif
 
 
-// resuts codes
+// result codes
 typedef enum 
 {
 	HASHOK,


### PR DESCRIPTION
There is a small typo in jwHash.h.

Should read `result` rather than `resuts`.

